### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+    - master
 
 jobs:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/geolib/models/dseries_parser.py
+++ b/geolib/models/dseries_parser.py
@@ -19,11 +19,10 @@ from typing import (
     get_type_hints,
 )
 
-from pydantic import FilePath
-
 from geolib.errors import ParserError
 from geolib.models import BaseDataClass as DataClass
 from geolib.models.base_model_structure import BaseModelStructure
+from pydantic import FilePath
 
 from .parsers import BaseParser
 from .utils import (

--- a/geolib/models/dseries_parser.py
+++ b/geolib/models/dseries_parser.py
@@ -19,10 +19,11 @@ from typing import (
     get_type_hints,
 )
 
+from pydantic import FilePath
+
 from geolib.errors import ParserError
 from geolib.models import BaseDataClass as DataClass
 from geolib.models.base_model_structure import BaseModelStructure
-from pydantic import FilePath
 
 from .parsers import BaseParser
 from .utils import (

--- a/geolib/models/dsheetpiling/dsheetpiling_structures.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_structures.py
@@ -102,7 +102,7 @@ class DSheetpilingUnwrappedTable(DSeriesStructure):
 class DSheetpilingTableEntry(DSeriesStructure):
     """Parses a table entry where the latest column is actually a name (which can be composed by a few strings.)
     E.g.:
-        Nr        Level        E-mod     Cross sect.    Length     YieldF   Side 
+        Nr        Level        E-mod     Cross sect.    Length     YieldF   Side
         1 -10.00  2.100E+0008  1.000E-0004  10.00 500.00 -30  0.00 2 Strut
     """
 
@@ -111,11 +111,17 @@ class DSheetpilingTableEntry(DSeriesStructure):
         values = [value for value in text.split() if value]
         # Remove the first value (it's just the line number)
         values.pop(0)
-        number_of_fields = len(get_type_hints(cls))
+
+        # In later versions __slots__ is a type hint too, function below is to ignore this key
+        type_hints = get_type_hints(cls)
+        if "__slots__" in type_hints:
+            type_hints.pop("__slots__")
+
+        number_of_fields = len(type_hints)
         name_field = " ".join(
             name_value for name_value in values[number_of_fields - 1 :] if name_value
         )
         rest_fields = values[0 : number_of_fields - 1]
         rest_fields.insert(0, name_field)
 
-        return cls(**dict(zip(get_type_hints(cls).keys(), rest_fields)))
+        return cls(**dict(zip(type_hints.keys(), rest_fields)))

--- a/geolib/models/utils.py
+++ b/geolib/models/utils.py
@@ -1,24 +1,31 @@
 # FROM https://github.com/python/cpython/blob/6292be7adf247589bbf03524f8883cb4cb61f3e9/Lib/typing.py
 import collections
+import sys
 from typing import Dict, List, Tuple, Type, _GenericAlias, _SpecialForm, get_type_hints
 
+if sys.version_info < (3, 9):
+    # Python 3.9 does not include `_special`, so use the function from typing instead
 
-def get_args(tp):
-    """Get type arguments with all substitutions performed.
-    For unions, basic simplifications used by Union constructor are performed.
-    Examples::
-        get_args(Dict[str, int]) == (str, int)
-        get_args(int) == ()
-        get_args(Union[int, Union[T, int], str][int]) == (int, str)
-        get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
-        get_args(Callable[[], T][int]) == ([], int)
-    """
-    if isinstance(tp, (_GenericAlias, _SpecialForm)) and not tp._special:
-        res = tp.__args__
-        if tp.__origin__ is collections.abc.Callable and res[0] is not Ellipsis:
-            res = (list(res[:-1]), res[-1])
-        return res
-    return ()
+    def get_args(tp):
+        """Get type arguments with all substitutions performed.
+        For unions, basic simplifications used by Union constructor are performed.
+        Examples::
+            get_args(Dict[str, int]) == (str, int)
+            get_args(int) == ()
+            get_args(Union[int, Union[T, int], str][int]) == (int, str)
+            get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
+            get_args(Callable[[], T][int]) == ([], int)
+        """
+        if isinstance(tp, (_GenericAlias, _SpecialForm)) and not tp._special:
+            res = tp.__args__
+            if tp.__origin__ is collections.abc.Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+        return ()
+
+
+else:
+    from typing import get_args as get_args  # NOQA
 
 
 def unpack_if_union(tp):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ build-backend = "poetry.masonry.api"
 
 [tox]
 isolated_build = true
-envlist = "py37, py38"
+envlist = "py37, py38, py39"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
At Antea Group we run python 3.9. During our runs we discovered that a few functions in Geolib are not working well with Geolib due to a missing argument `_special` and extra field `__slots__`. This PR solves those issues and also include python 3.9 to CI.