### PR TITLE
Fix: Set dates in projectinfo

### DIFF
--- a/geolib/models/dgeoflow/internal.py
+++ b/geolib/models/dgeoflow/internal.py
@@ -318,14 +318,14 @@ class ProjectInfo(DGeoFlowSubStructure):
     Remarks: Optional[str] = f"Created with GEOLib {version}"
 
     @validator("Created", "Date", "LastModified", pre=True, allow_reuse=True)
-    def nltime(cls, datestring):
-        if isinstance(datestring, str):
-            position = datestring.index(max(datestring.split("-"), key=len))
+    def nltime(cls, date: Union[date, str]) -> date:
+        if isinstance(date, str):
+            position = date.index(max(date.split("-"), key=len))
             if position > 0:
-                date = datetime.strptime(datestring, "%d-%M-%Y").date()
+                date = datetime.strptime(date, "%d-%m-%Y").date()
             else:
-                date = datetime.strptime(datestring, "%Y-%M-%d").date()
-            return date
+                date = datetime.strptime(date, "%Y-%m-%d").date()
+        return date
 
 
 class PersistablePoint(DGeoFlowBaseModelStructure):

--- a/geolib/models/dstability/internal.py
+++ b/geolib/models/dstability/internal.py
@@ -907,14 +907,14 @@ class ProjectInfo(DStabilitySubStructure):
     Remarks: Optional[str] = f"Created with GEOLib {version}"
 
     @validator("Created", "Date", "LastModified", pre=True, allow_reuse=True)
-    def nltime(cls, datestring):
-        if isinstance(datestring, str):
-            position = datestring.index(max(datestring.split("-"), key=len))
+    def nltime(cls, date: Union[date, str]) -> date:
+        if isinstance(date, str):
+            position = date.index(max(date.split("-"), key=len))
             if position > 0:
-                date = datetime.strptime(datestring, "%d-%M-%Y").date()
+                date = datetime.strptime(date, "%d-%m-%Y").date()
             else:
-                date = datetime.strptime(datestring, "%Y-%M-%d").date()
-            return date
+                date = datetime.strptime(date, "%Y-%m-%d").date()
+        return date
 
 
 class PersistableBondStress(DStabilityBaseModelStructure):

--- a/tests/models/dgeoflow/test_dgeoflow_internal.py
+++ b/tests/models/dgeoflow/test_dgeoflow_internal.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from geolib.models.dgeoflow.internal import (
     BoundaryConditionCollection,
     DGeoFlowStructure,
     ForeignKeys,
+    ProjectInfo,
 )
 from geolib.models.dstability.utils import children
 from tests.utils import TestUtils
@@ -62,3 +64,18 @@ class TestDGeoFlowInternal:
 
         # Verify result
         assert "PersistableBoundaryCondition" in child_classes
+
+    @pytest.mark.unittest
+    def test_projectinfo_validation(self):
+        projectinfo = ProjectInfo()
+
+        assert projectinfo.Created == datetime.now().date()
+
+        projectinfo = ProjectInfo(Created=datetime(2022, 11, 23))
+        assert projectinfo.Created == datetime(2022, 11, 23).date()
+
+        projectinfo = ProjectInfo(Created="23-11-2022")
+        assert projectinfo.Created == datetime(2022, 11, 23).date()
+
+        projectinfo = ProjectInfo(Created="2022-11-23")
+        assert projectinfo.Created == datetime(2022, 11, 23).date()

--- a/tests/models/dstability/test_dstability_internal.py
+++ b/tests/models/dstability/test_dstability_internal.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from geolib.models.dstability.internal import (
     DStabilityStructure,
     ForeignKeys,
     PersistableHeadLine,
+    ProjectInfo,
     Waternet,
 )
 from geolib.models.dstability.utils import children
@@ -108,3 +110,18 @@ class TestDStabilityInternal:
         # Verify
         assert stage_id == 1
         assert unique_id > unique_start_id
+
+    @pytest.mark.unittest
+    def test_projectinfo_validation(self):
+        projectinfo = ProjectInfo()
+
+        assert projectinfo.Created == datetime.now().date()
+
+        projectinfo = ProjectInfo(Created=datetime(2022, 11, 23))
+        assert projectinfo.Created == datetime(2022, 11, 23).date()
+
+        projectinfo = ProjectInfo(Created="23-11-2022")
+        assert projectinfo.Created == datetime(2022, 11, 23).date()
+
+        projectinfo = ProjectInfo(Created="2022-11-23")
+        assert projectinfo.Created == datetime(2022, 11, 23).date()


### PR DESCRIPTION
The current code of ProjectInfo will set the dates by default to None. This fix allows python date-objects and string values of a date for dutch and international specifications. This only applies to D-Stability and the copied code in D-Geoflow.