### PR TITLE
Add support for serializing to a BytesIO buffer

### DIFF
--- a/geolib/models/dfoundations/dfoundations_model.py
+++ b/geolib/models/dfoundations/dfoundations_model.py
@@ -1,8 +1,8 @@
 import logging
 from enum import Enum
-from io import BytesIO
 from pathlib import Path
 from subprocess import CompletedProcess, run
+from typing import BinaryIO
 from typing import List, Optional, Type, Union
 
 from pydantic import FilePath, confloat
@@ -166,10 +166,11 @@ class DFoundationsModel(BaseModel):
     def input(self):
         return self.datastructure.input_data
 
-    def serialize(self, filename: Union[FilePath, BytesIO]):
+    def serialize(self, filename: Union[FilePath, BinaryIO]):
         serializer = DFoundationsInputSerializer(ds=self.datastructure.dict())
         serializer.write(filename)
-        if not isinstance(filename, BytesIO):
+
+        if isinstance(filename, Path):
             self.filename = filename
 
     def set_model(

--- a/geolib/models/dfoundations/dfoundations_model.py
+++ b/geolib/models/dfoundations/dfoundations_model.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from io import BytesIO
 from pathlib import Path
 from subprocess import CompletedProcess, run
 from typing import List, Optional, Type, Union
@@ -165,10 +166,11 @@ class DFoundationsModel(BaseModel):
     def input(self):
         return self.datastructure.input_data
 
-    def serialize(self, filename: FilePath):
+    def serialize(self, filename: Union[FilePath, BytesIO]):
         serializer = DFoundationsInputSerializer(ds=self.datastructure.dict())
         serializer.write(filename)
-        self.filename = filename
+        if not isinstance(filename, BytesIO):
+            self.filename = filename
 
     def set_model(
         self,

--- a/geolib/models/dgeoflow/dgeoflow_model.py
+++ b/geolib/models/dgeoflow/dgeoflow_model.py
@@ -1,8 +1,8 @@
 import abc
 import re
 from enum import Enum
-from io import BytesIO
 from pathlib import Path
+from typing import BinaryIO
 from typing import Dict, List, Optional, Set, Type, Union
 
 from pydantic import DirectoryPath, FilePath
@@ -127,14 +127,15 @@ class DGeoFlowModel(BaseModel):
 
         raise ValueError(f"No result found for result id {scenario_index}")
 
-    def serialize(self, location: Union[FilePath, DirectoryPath, BytesIO]):
+    def serialize(self, location: Union[FilePath, DirectoryPath, BinaryIO]):
         """Support serializing to directory while developing for debugging purposes."""
-        if isinstance(location, BytesIO) or (isinstance(location, Path) and not location.is_dir()):
-            serializer = DGeoFlowInputZipSerializer(ds=self.datastructure)
-        else:
+        if isinstance(location, Path) and location.is_dir():
             serializer = DGeoFlowInputSerializer(ds=self.datastructure)
+        else:
+            serializer = DGeoFlowInputZipSerializer(ds=self.datastructure)
         serializer.write(location)
-        if not isinstance(location, BytesIO):
+
+        if isinstance(location, Path):
             self.filename = location
 
     def copy_scenario(self, label: str, notes: str, set_current=True) -> int:

--- a/geolib/models/dgeoflow/dgeoflow_model.py
+++ b/geolib/models/dgeoflow/dgeoflow_model.py
@@ -1,6 +1,7 @@
 import abc
 import re
 from enum import Enum
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Type, Union
 
@@ -126,14 +127,15 @@ class DGeoFlowModel(BaseModel):
 
         raise ValueError(f"No result found for result id {scenario_index}")
 
-    def serialize(self, location: Union[FilePath, DirectoryPath]):
+    def serialize(self, location: Union[FilePath, DirectoryPath, BytesIO]):
         """Support serializing to directory while developing for debugging purposes."""
-        if not location.is_dir():
+        if isinstance(location, BytesIO) or (isinstance(location, Path) and not location.is_dir()):
             serializer = DGeoFlowInputZipSerializer(ds=self.datastructure)
         else:
             serializer = DGeoFlowInputSerializer(ds=self.datastructure)
         serializer.write(location)
-        self.filename = location
+        if not isinstance(location, BytesIO):
+            self.filename = location
 
     def copy_scenario(self, label: str, notes: str, set_current=True) -> int:
         """Copy an existing scenario and add it to the model.

--- a/geolib/models/dsettlement/dsettlement_model.py
+++ b/geolib/models/dsettlement/dsettlement_model.py
@@ -83,7 +83,7 @@ class DSettlementModel(BaseModel):
     def console_flags(self) -> List[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
-    def serialize(self, filename: [FilePath, BinaryIO]):
+    def serialize(self, filename: Union[FilePath, BinaryIO]):
         """
         Serialize and pre-process
         Args:

--- a/geolib/models/dsettlement/dsettlement_model.py
+++ b/geolib/models/dsettlement/dsettlement_model.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from io import BytesIO
 from operator import attrgetter
 from pathlib import Path
 from subprocess import CompletedProcess, run
@@ -82,7 +83,7 @@ class DSettlementModel(BaseModel):
     def console_flags(self) -> List[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
-    def serialize(self, filename: FilePath):
+    def serialize(self, filename: [FilePath, BytesIO]):
         """
         Serialize and pre-process
         Args:
@@ -92,7 +93,9 @@ class DSettlementModel(BaseModel):
 
         serializer = DSettlementInputSerializer(ds=self.datastructure.dict())
         serializer.write(filename)
-        self.filename = filename
+
+        if not isinstance(filename, BytesIO):
+            self.filename = filename
 
     def add_soil(self, soil_input: Soil_Input) -> None:
         """Soil is converted in the internal structure and added in soil_collection."""

--- a/geolib/models/dsettlement/dsettlement_model.py
+++ b/geolib/models/dsettlement/dsettlement_model.py
@@ -1,9 +1,9 @@
 import logging
 from datetime import timedelta
-from io import BytesIO
 from operator import attrgetter
 from pathlib import Path
 from subprocess import CompletedProcess, run
+from typing import BinaryIO
 from typing import List, Optional, Type, Union
 
 from pydantic import FilePath, validate_arguments
@@ -83,7 +83,7 @@ class DSettlementModel(BaseModel):
     def console_flags(self) -> List[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
-    def serialize(self, filename: [FilePath, BytesIO]):
+    def serialize(self, filename: [FilePath, BinaryIO]):
         """
         Serialize and pre-process
         Args:
@@ -94,7 +94,7 @@ class DSettlementModel(BaseModel):
         serializer = DSettlementInputSerializer(ds=self.datastructure.dict())
         serializer.write(filename)
 
-        if not isinstance(filename, BytesIO):
+        if isinstance(filename, Path):
             self.filename = filename
 
     def add_soil(self, soil_input: Soil_Input) -> None:

--- a/geolib/models/dsheetpiling/dsheetpiling_model.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_model.py
@@ -1,8 +1,8 @@
 from abc import ABCMeta, abstractmethod
-from io import BytesIO
 from pathlib import Path
 from subprocess import CompletedProcess, run
 from typing import Any, List, Optional, Type, Union
+from typing import BinaryIO
 
 from pydantic import FilePath, PositiveFloat
 from pydantic.types import confloat, conint
@@ -154,7 +154,7 @@ class DSheetPilingModel(BaseModel):
     def model_type(self) -> Union[str, ModelType]:
         return self.datastructure.input_data.model.model
 
-    def serialize(self, filename: Union[FilePath, BytesIO]):
+    def serialize(self, filename: Union[FilePath, BinaryIO]):
         ds = self.datastructure.input_data.dict()
         ds.update(
             {
@@ -164,7 +164,7 @@ class DSheetPilingModel(BaseModel):
         )
         serializer = DSheetPilingInputSerializer(ds=ds)
         serializer.write(filename)
-        if not isinstance(filename, BytesIO):
+        if isinstance(filename, Path):
             self.filename = filename
 
     def _is_calculation_per_stage_required(self) -> bool:

--- a/geolib/models/dsheetpiling/dsheetpiling_model.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_model.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from io import BytesIO
 from pathlib import Path
 from subprocess import CompletedProcess, run
 from typing import Any, List, Optional, Type, Union
@@ -153,7 +154,7 @@ class DSheetPilingModel(BaseModel):
     def model_type(self) -> Union[str, ModelType]:
         return self.datastructure.input_data.model.model
 
-    def serialize(self, filename: FilePath):
+    def serialize(self, filename: Union[FilePath, BytesIO]):
         ds = self.datastructure.input_data.dict()
         ds.update(
             {
@@ -163,7 +164,8 @@ class DSheetPilingModel(BaseModel):
         )
         serializer = DSheetPilingInputSerializer(ds=ds)
         serializer.write(filename)
-        self.filename = filename
+        if not isinstance(filename, BytesIO):
+            self.filename = filename
 
     def _is_calculation_per_stage_required(self) -> bool:
         """Function that checks if [CALCULATION PER STAGE] can be modified. This is true for a verify sheet-piling calculation and method B."""

--- a/geolib/models/dstability/dstability_model.py
+++ b/geolib/models/dstability/dstability_model.py
@@ -1,6 +1,7 @@
 import abc
 import re
 from enum import Enum
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Type, Union
 
@@ -167,14 +168,15 @@ class DStabilityModel(BaseModel):
         result = self._get_result_substructure(stage_id)
         return result.get_slipplane_output()
 
-    def serialize(self, location: Union[FilePath, DirectoryPath]):
+    def serialize(self, location: Union[FilePath, DirectoryPath, BytesIO]):
         """Support serializing to directory while developing for debugging purposes."""
-        if not location.is_dir():
+        if isinstance(location, BytesIO) or (isinstance(location, Path) and not location.is_dir()):
             serializer = DStabilityInputZipSerializer(ds=self.datastructure)
         else:
             serializer = DStabilityInputSerializer(ds=self.datastructure)
         serializer.write(location)
-        self.filename = location
+        if not isinstance(location, BytesIO):
+            self.filename = location
 
     def add_stage(self, label: str, notes: str, set_current=True) -> int:
         """Add a new stage to the model.

--- a/geolib/models/dstability/dstability_model.py
+++ b/geolib/models/dstability/dstability_model.py
@@ -1,8 +1,8 @@
 import abc
 import re
 from enum import Enum
-from io import BytesIO
 from pathlib import Path
+from typing import BinaryIO
 from typing import Dict, List, Optional, Set, Type, Union
 
 from pydantic import DirectoryPath, FilePath
@@ -168,14 +168,14 @@ class DStabilityModel(BaseModel):
         result = self._get_result_substructure(stage_id)
         return result.get_slipplane_output()
 
-    def serialize(self, location: Union[FilePath, DirectoryPath, BytesIO]):
+    def serialize(self, location: Union[FilePath, DirectoryPath, BinaryIO]):
         """Support serializing to directory while developing for debugging purposes."""
-        if isinstance(location, BytesIO) or (isinstance(location, Path) and not location.is_dir()):
-            serializer = DStabilityInputZipSerializer(ds=self.datastructure)
-        else:
+        if isinstance(location, Path) and location.is_dir():
             serializer = DStabilityInputSerializer(ds=self.datastructure)
+        else:
+            serializer = DStabilityInputZipSerializer(ds=self.datastructure)
         serializer.write(location)
-        if not isinstance(location, BytesIO):
+        if isinstance(location, Path):
             self.filename = location
 
     def add_stage(self, label: str, notes: str, set_current=True) -> int:

--- a/geolib/models/serializers.py
+++ b/geolib/models/serializers.py
@@ -21,9 +21,9 @@ class BaseSerializer(BaseDataClass):
         """Write serialized model to Filepath or BytesIO buffer"""
         # if filename is pathlike, open file (in text mode) and write str
         if isinstance(filename, Path):
-            with open(filename, "w") as io:
+            with open(filename, "w", encoding='cp1252') as io:
                 io.write(self.render())
 
         # if filename is opened file (in binary mode) or BytesIO object, write render as bytes
         else:
-            filename.write(self.render().encode('utf-8'))
+            filename.write(self.render().encode('cp1252'))

--- a/geolib/models/serializers.py
+++ b/geolib/models/serializers.py
@@ -1,5 +1,6 @@
-from io import BytesIO
+from pathlib import Path
 from typing import Any
+from typing import BinaryIO
 from typing import Dict
 from typing import Union
 
@@ -16,9 +17,13 @@ class BaseSerializer(BaseDataClass):
     def render(self) -> str:
         return str(self.ds)
 
-    def write(self, filename: Union[FilePath, BytesIO]):
+    def write(self, filename: Union[FilePath, BinaryIO]):
         """Write serialized model to Filepath or BytesIO buffer"""
-        if isinstance(filename, BytesIO):
+        # if filename is pathlike, open file (in text mode) and write str
+        if isinstance(filename, Path):
+            with open(filename, "w") as io:
+                io.write(self.render())
+
+        # if filename is opened file (in binary mode) or BytesIO object, write render as bytes
+        else:
             filename.write(self.render().encode('utf-8'))
-        with open(filename, "w") as io:
-            io.write(self.render())

--- a/geolib/models/serializers.py
+++ b/geolib/models/serializers.py
@@ -1,4 +1,7 @@
-from typing import Any, Dict
+from io import BytesIO
+from typing import Any
+from typing import Dict
+from typing import Union
 
 from pydantic import FilePath
 
@@ -10,10 +13,12 @@ class BaseSerializer(BaseDataClass):
 
     ds: Dict[str, Any]
 
-    def render(self):
+    def render(self) -> str:
         return str(self.ds)
 
-    def write(self, filename: FilePath):
-        """Test."""
+    def write(self, filename: Union[FilePath, BytesIO]):
+        """Write serialized model to Filepath or BytesIO buffer"""
+        if isinstance(filename, BytesIO):
+            filename.write(self.render().encode('utf-8'))
         with open(filename, "w") as io:
             io.write(self.render())

--- a/tests/models/dfoundations/test_dfoundations_model.py
+++ b/tests/models/dfoundations/test_dfoundations_model.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from io import BytesIO
 from pathlib import Path
 from typing import Type
 
@@ -68,6 +69,38 @@ class TestDFoundationsModel:
         assert isinstance(dfoundation_model, BaseModel), (
             "" + "DFoundationsModel does not instanciate BaseModel"
         )
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_folder = Path(TestUtils.get_output_test_data_dir("dfoundations"))
+        filename = "serialized_from_intialized_model.foi"
+        output_test_file = output_test_folder / filename
+
+        # 2. Verify initial expectations
+        model = DFoundationsModel()
+        assert isinstance(model, DFoundationsModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert output_test_file.is_file()
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized_bytesio(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_file = BytesIO()
+
+        # 2. Verify initial expectations
+        model = DFoundationsModel()
+        assert isinstance(model, DFoundationsModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert isinstance(output_test_file, BytesIO)
 
     @pytest.mark.unittest
     def test_ensure_newlines_run_identification(self):
@@ -190,6 +223,18 @@ class TestDFoundationsModel:
     def test_execute_console_without_filename_raises_exception(self):
         # 1. Set up test data.
         df = DFoundationsModel()
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert df.execute()
+
+    @pytest.mark.unittest
+    def test_execute_console_with_bytesio_raises_exception(self):
+        # 1. Set up test data.
+        df = DFoundationsModel()
+
+        output_file = BytesIO()
+        df.serialize(output_file)
 
         # 2. Run test
         with pytest.raises(Exception):

--- a/tests/models/dgeoflow/test_dgeoflow_model.py
+++ b/tests/models/dgeoflow/test_dgeoflow_model.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import shutil
+from io import BytesIO
 from pathlib import Path
 from tkinter import Label
 
@@ -26,6 +27,38 @@ class TestDGeoFlowModel:
         assert isinstance(DGeoFlowModel(filename=None), BaseModel), (
             "" + "DGeoFlowModel does not instantiate BaseModel"
         )
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_folder = Path(TestUtils.get_output_test_data_dir("dgeoflow"))
+        filename = "serialized_from_intialized_model.flox"
+        output_test_file = output_test_folder / filename
+
+        # 2. Verify initial expectations
+        model = DGeoFlowModel()
+        assert isinstance(model, DGeoFlowModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert output_test_file.is_file()
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized_bytesio(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_file = BytesIO()
+
+        # 2. Verify initial expectations
+        model = DGeoFlowModel()
+        assert isinstance(model, DGeoFlowModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert isinstance(output_test_file, BytesIO)
 
     @pytest.mark.systemtest
     @pytest.mark.parametrize(
@@ -116,6 +149,27 @@ class TestDGeoFlowModel:
 
         # 3. Verify model output has been parsed
         assert model
+
+    @pytest.mark.unittest
+    def test_execute_console_without_filename_raises_exception(self):
+        # 1. Set up test data.
+        dm = DGeoFlowModel()
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert dm.execute()
+
+    @pytest.mark.unittest
+    def test_execute_console_with_bytesio_raises_exception(self):
+        # 1. Set up test data.
+        dm = DGeoFlowModel()
+
+        output_file = BytesIO()
+        dm.serialize(output_file)
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert dm.execute()
 
     @pytest.mark.acceptance
     def test_generate_groundwater_flow_model(self):

--- a/tests/models/dsettlement/test_dsettlement_model.py
+++ b/tests/models/dsettlement/test_dsettlement_model.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pathlib
 from datetime import timedelta
+from io import BytesIO
 from pathlib import Path
 from typing import List
 from warnings import warn
@@ -84,6 +85,38 @@ class TestDSettlementModel:
         assert isinstance(
             dsettlement_model, BaseModel
         ), "DSettlementModel does not instanciate BaseModel"
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_folder = Path(TestUtils.get_output_test_data_dir("dsettlement"))
+        filename = "serialized_from_intialized_model.sli"
+        output_test_file = output_test_folder / filename
+
+        # 2. Verify initial expectations
+        model = DSettlementModel()
+        assert isinstance(model, DSettlementModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert output_test_file.is_file()
+
+    @pytest.mark.unittest
+    def test_intialized_model_can_be_serialized_bytesio(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_file = BytesIO()
+
+        # 2. Verify initial expectations
+        model = DSettlementModel()
+        assert isinstance(model, DSettlementModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert isinstance(output_test_file, BytesIO)
 
     @pytest.mark.integrationtest
     @pytest.mark.parametrize(
@@ -183,11 +216,23 @@ class TestDSettlementModel:
     @pytest.mark.unittest
     def test_execute_console_without_filename_raises_exception(self):
         # 1. Set up test data.
-        df = DSettlementModel()
+        dm = DSettlementModel()
 
         # 2. Run test
         with pytest.raises(Exception):
-            assert df.execute()
+            assert dm.execute()
+
+    @pytest.mark.unittest
+    def test_execute_console_with_bytesio_raises_exception(self):
+        # 1. Set up test data.
+        dm = DSettlementModel()
+
+        output_file = BytesIO()
+        dm.serialize(output_file)
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert dm.execute()
 
     @pytest.mark.integrationtest
     def test_set_calculation_times(self):

--- a/tests/models/dsheetpiling/test_dsheetpiling_model.py
+++ b/tests/models/dsheetpiling/test_dsheetpiling_model.py
@@ -254,6 +254,18 @@ class TestDsheetPilingModel:
         with pytest.raises(Exception):
             assert df.execute()
 
+    @pytest.mark.unittest
+    def test_execute_console_with_bytesio_raises_exception(self):
+        # 1. Set up test data.
+        df = DSheetPilingModel()
+
+        output_file = BytesIO()
+        df.serialize(output_file)
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert df.execute()
+
     @pytest.mark.parametrize(
         "reverse_elements",
         [

--- a/tests/models/dsheetpiling/test_dsheetpiling_model.py
+++ b/tests/models/dsheetpiling/test_dsheetpiling_model.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from io import BytesIO
 from pathlib import Path
 from typing import List, Type
 
@@ -733,6 +734,20 @@ class TestDsheetPilingModel:
         model.serialize(output_test_file)
 
         assert output_test_file.is_file()
+
+    def test_intialized_model_can_be_serialized_bytesio(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_file = BytesIO()
+
+        # 2. Verify initial expectations
+        model = DSheetPilingModel()
+        assert isinstance(model, DSheetPilingModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert isinstance(output_test_file, BytesIO)
 
     @pytest.mark.integrationtest
     def test_add_surcharge_load(self, model: DSheetPilingModel):

--- a/tests/models/dstability/test_dstability_model.py
+++ b/tests/models/dstability/test_dstability_model.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import shutil
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,36 @@ class TestDStabilityModel:
         assert isinstance(DStabilityModel(filename=None), BaseModel), (
             "" + "DStabilityModel does not instantiate BaseModel"
         )
+
+    def test_intialized_model_can_be_serialized(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_folder = Path(TestUtils.get_output_test_data_dir("dstability"))
+        filename = "serialized_from_intialized_model.stix"
+        output_test_file = output_test_folder / filename
+
+        # 2. Verify initial expectations
+        model = DStabilityModel()
+        assert isinstance(model, DStabilityModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert output_test_file.is_file()
+
+    def test_intialized_model_can_be_serialized_bytesio(self):
+        """Internal datastructure should be serializable from a intialized model"""
+        # 1. setup test
+        output_test_file = BytesIO()
+
+        # 2. Verify initial expectations
+        model = DStabilityModel()
+        assert isinstance(model, DStabilityModel)
+
+        # 3. Run test.
+        model.serialize(output_test_file)
+
+        assert isinstance(output_test_file, BytesIO)
 
     @pytest.mark.systemtest
     @pytest.mark.parametrize(
@@ -142,6 +173,27 @@ class TestDStabilityModel:
 
         # 3. Verify model output has been parsed
         assert model
+
+    @pytest.mark.unittest
+    def test_execute_console_without_filename_raises_exception(self):
+        # 1. Set up test data.
+        dm = DStabilityModel()
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert dm.execute()
+
+    @pytest.mark.unittest
+    def test_execute_console_with_bytesio_raises_exception(self):
+        # 1. Set up test data.
+        dm = DStabilityModel()
+
+        output_file = BytesIO()
+        dm.serialize(output_file)
+
+        # 2. Run test
+        with pytest.raises(Exception):
+            assert dm.execute()
 
     @pytest.mark.integrationtest
     def test_add_default_stage(self):


### PR DESCRIPTION
Hi GEOLib team,

As discussed in issue #69, i would like GEOLib to support BytesIO buffers for serialization. In this PR, I have modified the serialize functions on the models and serializers to both allow local file paths and BytesIO buffers.

These modifications are fully backwards compatible, so the old functionality is unchanged.

Let me know what you think?

closes #69 