### PR TITLE
Bugfix shear strengh model parameters not getting through in DStabilility 2023

### DIFF
--- a/geolib/soils/soil.py
+++ b/geolib/soils/soil.py
@@ -552,7 +552,7 @@ class Soil(SoilBaseModel):
                     self.mohr_coulomb_parameters.dilatancy_angle
                 ),
             },
-            "ShansepShearStrengthModel": {
+            "SuShearStrengthModel": {
                 "ShearStrengthRatio": self.undrained_parameters.shear_strength_ratio.mean,
                 "ShearStrengthRatioStochasticParameter": self.__to_dstability_stochastic_parameter(
                     self.undrained_parameters.shear_strength_ratio


### PR DESCRIPTION
"ShansepShearStrengthModel" in GEOlib is called "SuShearStrengthModel" in soils.json (when unzipping a .stix file)