### PR TITLE
fix: Leaking username and password when using API service

### DIFF
--- a/geolib/models/base_model.py
+++ b/geolib/models/base_model.py
@@ -31,7 +31,6 @@ meta = MetaData()
 class BaseModel(BaseDataClass, abc.ABC):
     filename: Optional[Path]
     datastructure: Optional[BaseModelStructure]
-    meta: MetaData = MetaData()
 
     def execute(self, timeout_in_seconds: int = meta.timeout) -> "BaseModel":
         """Execute a Model and wait for `timeout` seconds.
@@ -45,7 +44,7 @@ class BaseModel(BaseDataClass, abc.ABC):
             logger.warning("Serializing before executing.")
             self.serialize(self.filename)
 
-        executable = self.meta.console_folder / self.console_path
+        executable = meta.console_folder / self.console_path
         if not executable.exists():
             logger.error(
                 f"Please make sure the `geolib.env` file points to the console folder. GEOLib now can't find it at `{executable}`"
@@ -95,7 +94,7 @@ class BaseModel(BaseDataClass, abc.ABC):
                 endpoint, f"calculate/{self.__class__.__name__.lower()}"
             ),
             data=self.json(),
-            auth=HTTPBasicAuth(self.meta.gl_username, self.meta.gl_password),
+            auth=HTTPBasicAuth(meta.gl_username, meta.gl_password),
         )
         if response.status_code == 200:
             data = response.json()
@@ -167,10 +166,6 @@ class BaseModel(BaseDataClass, abc.ABC):
             logger.warning("No datastructured parsed yet!")
             return False
 
-    def set_metadata(self, meta: MetaData):
-        """Set custom metadata for input file."""
-        self.metadata = meta
-
     @property
     def input(self):
         """Access internal dict-like datastructure of the input."""
@@ -193,7 +188,6 @@ class BaseModelList(BaseDataClass):
     identifying them later."""
 
     models: List[BaseModel]
-    meta: MetaData = MetaData()
     errors: List[str] = []
 
     def execute(
@@ -229,7 +223,7 @@ class BaseModelList(BaseDataClass):
                 fn = unique_folder / model.filename.name
                 model.serialize(fn.resolve())
 
-            executable = self.meta.console_folder / lead_model.console_path
+            executable = meta.console_folder / lead_model.console_path
             if not executable.exists():
                 logger.error(
                     f"Please make sure the `geolib.env` file points to the console folder. GEOLib now can't find it at `{executable}`"
@@ -286,7 +280,7 @@ class BaseModelList(BaseDataClass):
                 endpoint, f"calculate/{lead_model.__class__.__name__.lower()}s"
             ),
             data="[" + ",".join((model.json() for model in self.models)) + "]",
-            auth=HTTPBasicAuth(lead_model.meta.gl_username, lead_model.meta.gl_password),
+            auth=HTTPBasicAuth(meta.gl_username, meta.gl_password),
         )
         if response.status_code == 200:
             models = response.json()["models"]

--- a/geolib/service/main.py
+++ b/geolib/service/main.py
@@ -59,15 +59,12 @@ def cleanup(path: Path):
     shutil.rmtree(path)
 
 
-def execute(model, background_tasks: BackgroundTasks):
+def execute(model: BaseModel, background_tasks: BackgroundTasks):
     unique_id = str(uuid.uuid4())
     unique_folder = Path(settings.calculation_folder / unique_id).absolute()
     unique_folder.mkdir(parents=True, exist_ok=True)
     ext = model.parser_provider_type().input_parsers[0].suffix_list[0]
     model.serialize(unique_folder / f"{unique_id}{ext}")
-
-    # Override console folder from client
-    model.meta.console_folder = settings.console_folder
 
     try:
         output = model.execute()


### PR DESCRIPTION
I encountered this issue while working on a migration branch to support Pydantic v2. The problem is related to the leakage of confidential information in the API documentation. Specifically, the API documentation is revealing the username and password used by the Geolib calculation webservice. This is due to the metadata being included in the model, which, during runtime, exposes the username and password in plain text.