### PR TITLE
Fix/geolib 217 result serializer issue dstability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ requests.egg-info/
 *.pyc
 *.swp
 *.egg
+.env/
 env/
 .venv/
 venv/

--- a/geolib/models/dgeoflow/serializer.py
+++ b/geolib/models/dgeoflow/serializer.py
@@ -90,7 +90,10 @@ class DGeoFlowInputZipSerializer(DGeoFlowBaseSerializer):
                 if isinstance(data, dict):
                     folder = filename
                     for ffilename, fdata in data.items():
-                        fn = folder + "/" + ffilename
+                        if folder[-1] == "/":
+                            fn = folder + ffilename
+                        else:
+                            fn = folder + "/" + ffilename
                         with zip.open(fn, "w") as io:
                             io.write(fdata.encode("utf-8"))
                 else:

--- a/geolib/models/dstability/serializer.py
+++ b/geolib/models/dstability/serializer.py
@@ -90,7 +90,10 @@ class DStabilityInputZipSerializer(DStabilityBaseSerializer):
                 if isinstance(data, dict):
                     folder = filename
                     for ffilename, fdata in data.items():
-                        fn = folder + "/" + ffilename
+                        if folder[-1] == "/":
+                            fn = folder + ffilename
+                        else:
+                            fn = folder + "/" + ffilename
                         with zip.open(fn, "w") as io:
                             io.write(fdata.encode("utf-8"))
                 else:


### PR DESCRIPTION
When calling DStability 2024.1 from VRTool via GEOLib the execution crashes on results folder in the stix.
Cause: an additional level is introduced during the writing to stix.
Solution: remove trailing '/'