### PR TITLE
added option to use None for headlines in referencelines dstability

### DIFF
--- a/geolib/models/dstability/dstability_model.py
+++ b/geolib/models/dstability/dstability_model.py
@@ -567,12 +567,12 @@ class DStabilityModel(BaseModel):
                 linestring1, linestring2 = self.connect_layers(layer, new_layer)
 
                 # Update the points of the layers
-                current_layers[
-                    current_layers.index(layer)
-                ].Points = self.to_dstability_points(linestring1)
-                current_layers[
-                    current_layers.index(new_layer)
-                ].Points = self.to_dstability_points(linestring2)
+                current_layers[current_layers.index(layer)].Points = (
+                    self.to_dstability_points(linestring1)
+                )
+                current_layers[current_layers.index(new_layer)].Points = (
+                    self.to_dstability_points(linestring2)
+                )
 
     def to_shapely_linestring(self, points: List[PersistablePoint]) -> LineString:
         converted_points = [(p.X, p.Z) for p in points]
@@ -671,13 +671,13 @@ class DStabilityModel(BaseModel):
         persistable_headline = waternet.add_head_line(
             str(self._get_next_id()), label, notes, points, is_phreatic_line
         )
-        return int(persistable_headline.Id)
+        return persistable_headline.Id
 
     def add_reference_line(
         self,
         points: List[Point],
-        bottom_headline_id: int,
-        top_head_line_id: int,
+        bottom_headline_id: Optional[str] = None,
+        top_head_line_id: Optional[str] = None,
         label: str = "",
         notes: str = "",
         scenario_index: Optional[int] = None,
@@ -708,8 +708,8 @@ class DStabilityModel(BaseModel):
             label,
             notes,
             points,
-            str(bottom_headline_id),
-            str(top_head_line_id),
+            bottom_headline_id,
+            top_head_line_id,
         )
         return int(persistable_reference_line.Id)
 

--- a/geolib/models/dstability/internal.py
+++ b/geolib/models/dstability/internal.py
@@ -169,20 +169,22 @@ class Waternet(DStabilitySubStructure):
         label: str,
         notes: str,
         points: List[Point],
-        bottom_head_line_id: str,
-        top_head_line_id: str,
+        bottom_head_line_id: Optional[str] = None,
+        top_head_line_id: Optional[str] = None,
     ) -> PersistableReferenceLine:
         reference_line = PersistableReferenceLine(
             Id=reference_line_id, Label=label, Notes=notes
         )
         reference_line.Points = [PersistablePoint(X=p.x, Z=p.z) for p in points]
 
-        if not self.has_head_line_id(bottom_head_line_id):
+        if bottom_head_line_id is not None and not self.has_head_line_id(
+            bottom_head_line_id
+        ):
             raise ValueError(
                 f"Unknown headline id {bottom_head_line_id} for bottom_head_line_id"
             )
 
-        if not self.has_head_line_id(top_head_line_id):
+        if top_head_line_id is not None and not self.has_head_line_id(top_head_line_id):
             raise ValueError(
                 f"Unknown headline id {top_head_line_id} for top_head_line_id"
             )
@@ -227,13 +229,13 @@ class WaternetCreatorSettings(DStabilitySubStructure):
     AquitardHeadLandSide: Optional[Union[float, str]] = "NaN"
     AquitardHeadWaterSide: Optional[Union[float, str]] = "NaN"
     ContentVersion: Optional[str] = "2"
-    DitchCharacteristics: Optional[
-        PersistableDitchCharacteristics
-    ] = PersistableDitchCharacteristics()
+    DitchCharacteristics: Optional[PersistableDitchCharacteristics] = (
+        PersistableDitchCharacteristics()
+    )
     DrainageConstruction: Optional[PersistablePoint] = PersistablePoint()
-    EmbankmentCharacteristics: Optional[
-        PersistableEmbankmentCharacteristics
-    ] = PersistableEmbankmentCharacteristics()
+    EmbankmentCharacteristics: Optional[PersistableEmbankmentCharacteristics] = (
+        PersistableEmbankmentCharacteristics()
+    )
     EmbankmentSoilScenario: EmbankmentSoilScenarioEnum = (
         EmbankmentSoilScenarioEnum.CLAY_EMBANKMENT_ON_CLAY
     )
@@ -711,18 +713,18 @@ class PersistableSoil(DStabilityBaseModelStructure):
     IsProbabilistic: bool = False
     Name: Optional[str] = ""
     Notes: Optional[str] = ""
-    ShearStrengthModelTypeAbovePhreaticLevel: ShearStrengthModelTypePhreaticLevelInternal = (
-        ShearStrengthModelTypePhreaticLevelInternal.MOHR_COULOMB_ADVANCED
-    )
-    ShearStrengthModelTypeBelowPhreaticLevel: ShearStrengthModelTypePhreaticLevelInternal = (
-        ShearStrengthModelTypePhreaticLevelInternal.SU
-    )
-    MohrCoulombClassicShearStrengthModel: PersistableMohrCoulombClassicShearStrengthModel = (
-        PersistableMohrCoulombClassicShearStrengthModel()
-    )
-    MohrCoulombAdvancedShearStrengthModel: PersistableMohrCoulombAdvancedShearStrengthModel = (
-        PersistableMohrCoulombAdvancedShearStrengthModel()
-    )
+    ShearStrengthModelTypeAbovePhreaticLevel: (
+        ShearStrengthModelTypePhreaticLevelInternal
+    ) = ShearStrengthModelTypePhreaticLevelInternal.MOHR_COULOMB_ADVANCED
+    ShearStrengthModelTypeBelowPhreaticLevel: (
+        ShearStrengthModelTypePhreaticLevelInternal
+    ) = ShearStrengthModelTypePhreaticLevelInternal.SU
+    MohrCoulombClassicShearStrengthModel: (
+        PersistableMohrCoulombClassicShearStrengthModel
+    ) = PersistableMohrCoulombClassicShearStrengthModel()
+    MohrCoulombAdvancedShearStrengthModel: (
+        PersistableMohrCoulombAdvancedShearStrengthModel
+    ) = PersistableMohrCoulombAdvancedShearStrengthModel()
     SuShearStrengthModel: PersistableSuShearStrengthModel = (
         PersistableSuShearStrengthModel()
     )
@@ -1158,9 +1160,9 @@ class NailProperties(DStabilitySubStructure):
     """nailpropertiesforsoils.json"""
 
     ContentVersion: Optional[str] = "2"
-    NailPropertiesForSoils: Optional[
-        List[Optional[PersistableNailPropertiesForSoil]]
-    ] = []
+    NailPropertiesForSoils: Optional[List[Optional[PersistableNailPropertiesForSoil]]] = (
+        []
+    )
 
     @classmethod
     def structure_name(cls) -> str:
@@ -1474,13 +1476,13 @@ class PersistableTangentLines(DStabilityBaseModelStructure):
 
 
 class PersistableBishopBruteForceSettings(DStabilityBaseModelStructure):
-    GridEnhancements: Optional[
-        PersistableGridEnhancements
-    ] = PersistableGridEnhancements()
+    GridEnhancements: Optional[PersistableGridEnhancements] = (
+        PersistableGridEnhancements()
+    )
     SearchGrid: Optional[PersistableSearchGrid] = PersistableSearchGrid()
-    SlipPlaneConstraints: Optional[
-        PersistableSlipPlaneConstraints
-    ] = PersistableSlipPlaneConstraints()
+    SlipPlaneConstraints: Optional[PersistableSlipPlaneConstraints] = (
+        PersistableSlipPlaneConstraints()
+    )
     TangentLines: Optional[PersistableTangentLines] = PersistableTangentLines()
 
 
@@ -1504,9 +1506,9 @@ class PersistableSpencerSettings(DStabilityBaseModelStructure):
     Label: Optional[str] = ""
     Notes: Optional[str] = ""
     SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
-    SlipPlaneConstraints: Optional[
-        PersistableGeneticSlipPlaneConstraints
-    ] = PersistableGeneticSlipPlaneConstraints()
+    SlipPlaneConstraints: Optional[PersistableGeneticSlipPlaneConstraints] = (
+        PersistableGeneticSlipPlaneConstraints()
+    )
 
 
 class OptionsTypeEnum(Enum):
@@ -1523,9 +1525,9 @@ class PersistableSpencerGeneticSettings(DStabilityBaseModelStructure):
     OptionsType: Optional[OptionsTypeEnum] = OptionsType.DEFAULT
     SlipPlaneA: Optional[List[Optional[PersistablePoint]]] = None
     SlipPlaneB: Optional[List[Optional[PersistablePoint]]] = None
-    SlipPlaneConstraints: Optional[
-        PersistableGeneticSlipPlaneConstraints
-    ] = PersistableGeneticSlipPlaneConstraints()
+    SlipPlaneConstraints: Optional[PersistableGeneticSlipPlaneConstraints] = (
+        PersistableGeneticSlipPlaneConstraints()
+    )
 
 
 class PersistableTwoCirclesOnTangentLine(DStabilityBaseModelStructure):
@@ -1537,9 +1539,9 @@ class PersistableTwoCirclesOnTangentLine(DStabilityBaseModelStructure):
 class PersistableUpliftVanSettings(DStabilityBaseModelStructure):
     Label: Optional[str] = ""
     Notes: Optional[str] = ""
-    SlipPlane: Optional[
-        PersistableTwoCirclesOnTangentLine
-    ] = PersistableTwoCirclesOnTangentLine()
+    SlipPlane: Optional[PersistableTwoCirclesOnTangentLine] = (
+        PersistableTwoCirclesOnTangentLine()
+    )
 
 
 class PersistableSearchArea(DStabilityBaseModelStructure):
@@ -1563,9 +1565,9 @@ class PersistableUpliftVanParticleSwarmSettings(DStabilityBaseModelStructure):
     OptionsType: Optional[OptionsTypeEnum] = OptionsType.DEFAULT
     SearchAreaA: Optional[PersistableSearchArea] = PersistableSearchArea()
     SearchAreaB: Optional[PersistableSearchArea] = PersistableSearchArea()
-    SlipPlaneConstraints: Optional[
-        PersistableSlipPlaneConstraints
-    ] = PersistableSlipPlaneConstraints()
+    SlipPlaneConstraints: Optional[PersistableSlipPlaneConstraints] = (
+        PersistableSlipPlaneConstraints()
+    )
     TangentArea: Optional[PersistableTangentArea] = PersistableTangentArea()
 
 
@@ -1574,22 +1576,22 @@ class CalculationSettings(DStabilitySubStructure):
 
     AnalysisType: Optional[AnalysisTypeEnum] = AnalysisTypeEnum.BISHOP_BRUTE_FORCE
     Bishop: Optional[PersistableBishopSettings] = PersistableBishopSettings()
-    BishopBruteForce: Optional[
-        PersistableBishopBruteForceSettings
-    ] = PersistableBishopBruteForceSettings()
+    BishopBruteForce: Optional[PersistableBishopBruteForceSettings] = (
+        PersistableBishopBruteForceSettings()
+    )
     CalculationType: Optional[CalculationTypeEnum] = CalculationTypeEnum.DETERMINISTIC
     ContentVersion: Optional[str] = "2"
     Id: Optional[str] = "19"
     ModelFactorMean: Optional[float] = 1.05
     ModelFactorStandardDeviation: Optional[float] = 0.033
     Spencer: Optional[PersistableSpencerSettings] = PersistableSpencerSettings()
-    SpencerGenetic: Optional[
-        PersistableSpencerGeneticSettings
-    ] = PersistableSpencerGeneticSettings()
+    SpencerGenetic: Optional[PersistableSpencerGeneticSettings] = (
+        PersistableSpencerGeneticSettings()
+    )
     UpliftVan: Optional[PersistableUpliftVanSettings] = PersistableUpliftVanSettings()
-    UpliftVanParticleSwarm: Optional[
-        PersistableUpliftVanParticleSwarmSettings
-    ] = PersistableUpliftVanParticleSwarmSettings()
+    UpliftVanParticleSwarm: Optional[PersistableUpliftVanParticleSwarmSettings] = (
+        PersistableUpliftVanParticleSwarmSettings()
+    )
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:

--- a/tests/models/dstability/test_waternets.py
+++ b/tests/models/dstability/test_waternets.py
@@ -53,3 +53,22 @@ class TestDStabilityReferenceLine:
                 bottom_headline_id=-1,
                 top_head_line_id=head_line_2_id,
             )
+
+    @pytest.mark.unittest
+    def test_add_interpolation(self):
+        dsm = DStabilityModel()
+
+        points = [Point(x=-20.0, z=-2.0), Point(x=50.0, z=-2.0)]
+        _ = dsm.add_head_line(label="TestHL_1", points=points, is_phreatic_line=True)
+        head_line_2_id = dsm.add_head_line(
+            label="TestHL_2", points=points, is_phreatic_line=False
+        )
+
+        # adding valid reference line with interpolation
+        _ = dsm.add_reference_line(
+            label="TestRL",
+            points=points,
+            top_head_line_id=head_line_2_id,
+        )
+        assert dsm.waternets[0].ReferenceLines[0].BottomHeadLineId is None
+        assert dsm.waternets[0].ReferenceLines[0].TopHeadLineId == head_line_2_id

--- a/tests/models/dstability/test_waternets.py
+++ b/tests/models/dstability/test_waternets.py
@@ -13,7 +13,7 @@ class TestDStabilityHeadLine:
             label="TestHL", points=points, is_phreatic_line=True
         )
         headline = dsm.datastructure.waternets[0].get_head_line(str(headline_id))
-        assert isinstance(headline_id, int)
+        assert isinstance(headline_id, str)
         assert pytest.approx(headline.Points[0].X) == -20.0
         assert dsm.waternets[0].PhreaticLineId == headline.Id
 


### PR DESCRIPTION
Added code to allow the definition of referencelines in DStability with None as value for the top- and bottomheadlines to allow interpolation. 

Added testcase

Unfortunately black autoformats my code diffently so there are more (layout) changes that are not actually changes in the pull request code