### PR TITLE
Change tests to use a loop instead of list comprehension

### DIFF
--- a/docs/community/tutorial_dgeoflow.rst
+++ b/docs/community/tutorial_dgeoflow.rst
@@ -74,7 +74,8 @@ it to the model.
         (embankment, "H_Aa_ht_old"),
     ]
     
-    [dm.add_layer(points, soil) for points, soil in layers_and_soils]
+    for points, soil in layers_and_soils:
+        dm.add_layer(points, soil)
 
 5. With the geometry defined, let's add the boundary conditions.
 

--- a/examples/dgeoflow/tutorial/tutorial.py
+++ b/examples/dgeoflow/tutorial/tutorial.py
@@ -56,7 +56,8 @@ layers_and_soils = [
     (embankment, "H_Aa_ht_old"),
 ]
 
-[dm.add_layer(points, soil) for points, soil in layers_and_soils]
+for points, soil in layers_and_soils:
+    dm.add_layer(points, soil)
 
 river_boundary_id = dm.add_boundary_condition(
     [Point(x=-50, z=0), Point(x=-10, z=0)], 17, "River"

--- a/tests/models/dgeoflow/test_dgeoflow_model.py
+++ b/tests/models/dgeoflow/test_dgeoflow_model.py
@@ -209,7 +209,8 @@ class TestDGeoFlowModel:
             (embankment, "H_Aa_ht_old"),
         ]
 
-        [dm.add_layer(points, soil) for points, soil in layers_and_soils]
+        for points, soil in layers_and_soils:
+            dm.add_layer(points, soil)
 
         dm.add_boundary_condition([Point(x=-50, z=0), Point(x=-10, z=0)], 3, "River")
         dm.add_boundary_condition([Point(x=30, z=0), Point(x=50, z=0)], 0, "Polder")
@@ -266,7 +267,8 @@ class TestDGeoFlowModel:
             (embankment, "H_Aa_ht_old"),
         ]
 
-        [dm.add_layer(points, soil) for points, soil in layers_and_soils]
+        for points, soil in layers_and_soils:
+            dm.add_layer(points, soil)
 
         dm.add_boundary_condition([Point(x=-50, z=0), Point(x=-10, z=0)], 17, "River")
         dm.add_boundary_condition([Point(x=30, z=0), Point(x=50, z=0)], 0, "Polder")
@@ -338,7 +340,8 @@ class TestDGeoFlowModel:
             (embankment, "H_Aa_ht_old"),
         ]
 
-        [dm.add_layer(points, soil) for points, soil in layers_and_soils]
+        for points, soil in layers_and_soils:
+            dm.add_layer(points, soil)
 
         river_boundary_id = dm.add_boundary_condition(
             [Point(x=-50, z=0), Point(x=-10, z=0)], 17, "River"

--- a/tests/models/dstability/test_dstability_model.py
+++ b/tests/models/dstability/test_dstability_model.py
@@ -399,7 +399,12 @@ class TestDStabilityModel:
             (embankment, "H_Aa_ht_old"),
         ]
 
-        layer_ids = [dm.add_layer(points, soil) for points, soil in layers_and_soils]
+        layer_ids = []
+
+        for points, soil in layers_and_soils:
+            layer_id = dm.add_layer(points, soil)
+            layer_ids.append(layer_id)
+
         for layer_id in layer_ids:
             # Has to be done in a separate loop since all layers first need to be defined.
             dm.add_soil_layer_consolidations(soil_layer_id=layer_id)


### PR DESCRIPTION
Some tests used list comprehension to repeatedly execute a task. This is not Pythonic. This PR replaces the list comprehensions with simple for-loops and improves code consistency.